### PR TITLE
add _stricmp define for Windows

### DIFF
--- a/src/txt/AttributedString.cpp
+++ b/src/txt/AttributedString.cpp
@@ -12,6 +12,10 @@
 #include "txt/Font.h"
 #include "txt/FontManager.h"
 
+#if defined( CINDER_MSW_DESKTOP )
+#define stricmp _stricmp
+#endif
+
 using namespace rapidxml;
 
 namespace txt


### PR DESCRIPTION
A fix to help the Windows compiler get past this error:
```
'stricmp': The POSIX name for this item is deprecated. 
Instead, use the ISO C and C++ conformant name: _stricmp.
.....\src\txt\attributedstring.cpp    222
```
Not sure if `CINDER_MSW_DESKTOP` is what you want to use, but it worked for the project I have.