### PR TITLE
fix cache miss and extra calls to getGlyphBitmap

### DIFF
--- a/src/txt/TextRendererGl.cpp
+++ b/src/txt/TextRendererGl.cpp
@@ -36,8 +36,6 @@ namespace txt
 				for( auto& glyph : run.glyphs ) {
 					ci::gl::ScopedMatrices matrices;
 
-					FT_BitmapGlyph ftGlyph = txt::FontManager::get()->getGlyphBitmap( run.font, glyph.index );
-
 					ci::gl::translate( ci::vec2( glyph.bbox.getUpperLeft() ) );
 					drawGlyph( run.font, glyph.index );
 				}
@@ -64,7 +62,7 @@ namespace txt
 	ci::gl::TextureRef RendererGl::getGlyphTexture( const  Font& font, unsigned int glyphIndex )
 	{
 		// Check to see if we have the font
-		if( mGlyphTextures.count( font ) == 0 || mGlyphTextures[font].count( glyphIndex ) ) {
+		if( mGlyphTextures.count( font ) == 0 || mGlyphTextures[font].count( glyphIndex ) == 0 ) {
 			cacheGlyphAsTexture( font, glyphIndex );
 		}
 


### PR DESCRIPTION
Ritesh discovered some extra calls to `getGlyphBitmap`, one explicitly in `draw` and one that happens when the cache gets missed in `getGlyphTexture`. This fix significantly sped up the app we were testing it in (and may resolve some reported memory leaks?)