### PR TITLE
use more portable _stricmp

### DIFF
--- a/src/txt/AttributedString.cpp
+++ b/src/txt/AttributedString.cpp
@@ -178,7 +178,7 @@ namespace txt
 			if( node->value_size() != 0 ) {
 				mSubstrings.push_back( AttributedString::Substring( node->value(), mAttributesStack.top() ) );
 			}
-			else if( stricmp( node->name(), ATTR_LINE_BREAK ) == 0 ) {
+			else if( _stricmp( node->name(), ATTR_LINE_BREAK ) == 0 ) {
 				if( !mSubstrings.size() ) {
 					mSubstrings.push_back( AttributedString::Substring( "\n", mAttributesStack.top() ) );
 				}

--- a/src/txt/TextLayout.cpp
+++ b/src/txt/TextLayout.cpp
@@ -263,7 +263,7 @@ namespace txt
 
 
 			for( auto& index : shapedGlyphs[i].textIndices ) {
-				ci::app::console() << lineBreaks[index] << std::endl;
+				//ci::app::console() << lineBreaks[index] << std::endl;
 
 				if( lineBreaks[index] == ci::UNICODE_MUST_BREAK ) {
 					// Add the current run then move to next line


### PR DESCRIPTION
I hit a compiler error on `stricmp`, but `_stricmp` worked